### PR TITLE
Updated npm to version 3.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "get-parameter-names": "0.2.0",
     "minimist": "1.2.0",
     "native-promise-only": "0.8.1",
-    "npm": "3.3.4",
+    "npm": "3.3.5",
     "object-values": "1.0.0",
     "package-path": "0.0.1",
     "pigato": "git@github.com:prdn/pigato.git#master",


### PR DESCRIPTION
:rocket:

npm just published version 3.3.5, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
[GitHub Release](https://github.com/npm/npm/releases/tag/v3.3.5)

### v3.3.5 (2015-09-24):

Some of you all may not be aware, but npm is ALSO a company. I tell you this 'cause npm-the-company had an all-staff get together this week, flying in our remote folks from around the world. That was great, but it also basically eliminated normal work on Monday and Tuesday.

Still, we've got a couple of really important bug fixes this week. Plus a lil bit from the [now LTS 2.x branch](https://github.com/npm/npm/releases/tag/v2.14.6).

#### ATTENTION WINDOWS USERS

If you previously updated to npm 3 and you try to update again, you may get an error messaging telling you that npm won't install npm into itself. Until you are at 3.3.5 or greater, you can get around this with `npm install -f -g npm`.

* [`bef06f5`](https://github.com/npm/npm/commit/bef06f5) [#9741](https://github.com/npm/npm/pull/9741) Uh... so... er... it seems that since npm@3.2.0 on Windows with a default configuration, it's been impossible to update npm. Well, that's not actually true, there's a work around (see above), but it shouldn't be complaining in the first place. ([@iarna](https://github.com/iarna))

#### STACK OVERFLOWS ON PUBLISH

* [`330b496`](https://github.com/npm/npm/commit/330b496) [#9667](https://github.com/npm/npm/pull/9667) We were keeping track of metadata about your project while packing the tree in a way that resulted in this data being written to packed tar files headers. When this metadata included cycles, it resulted in the the tar file entering an infinite recursive loop and eventually crashing with a stack overflow.

  I've patched this by keeping track of your metadata by closing over the variables in question instead, and I've further restricted gathering and tracking the metadata to times when it's actually needed. (Which is only if you need bundled modules.) ([@iarna](https://github.com/iarna))

#### LESS CRASHY ERROR MESSAGES ON BAD PACKAGES

* [`829921f`](https://github.com/npm/npm/commit/829921f) [#9741](https://github.com/npm/npm/pull/9741) Packages with invalid names or versions were crashing the installer. These are now captured and warned as was originally intended. ([@iarna](https://github.com/iarna))

#### ONE DEPENDENCY UPDATE

* [`963295c`](https://github.com/npm/npm/commit/963295c) npm-install-checks@2.0.1 ([@iarna](https://github.com/iarna))

#### AND ONE SUBDEPENDENCY

* [`448737d`](https://github.com/npm/npm/commit/448737d) request@2.63.0 ([@simov](https://github.com/simov))


---
The new version differs by 19 commits (ahead by 19, behind by 0).

- [5653606](https://github.com/npm/npm/commit/5653606a12616dbe39d456be7238f00fe51f8816): 3.3.5
- [5740181](https://github.com/npm/npm/commit/57401813f72eb84089fe2eefa1b799910dc137f4): update AUTHORS
- [94d80b8](https://github.com/npm/npm/commit/94d80b828b6842e22b816bdea81fcdff119ecf2b): test: spaces for standard
- [4de3df1](https://github.com/npm/npm/commit/4de3df1fa1c1c1f3793c31982c1e43c36fb02fd0): test: Use unique package names in tests!
- [ff47bc1](https://github.com/npm/npm/commit/ff47bc138e877835f1c0f419fea5f5672110678a): doc: CHANGELOG for 3.3.5
- [d7d4f8a](https://github.com/npm/npm/commit/d7d4f8a17caa99ffbf95cc93c1ab3f8ebc2c8e59): doc: Update changelog for 2.14.6
- [7a8d7e5](https://github.com/npm/npm/commit/7a8d7e51c5f89486aae4f0384b6875e29f417975): cache: also update port when updating protocol
- [05444d7](https://github.com/npm/npm/commit/05444d76ad287ddf209d6e1264d680acc42d8e4d): gitignore: Add subsubdep required by updated subdep
- [e121fd9](https://github.com/npm/npm/commit/e121fd91e4aea3d36e41e6024eaf2a22c980017a): nock@2.12.0
- [448737d](https://github.com/npm/npm/commit/448737d189de47a4285e135e277194e5916023c5): request@2.63.0
- [963295c](https://github.com/npm/npm/commit/963295c8a0c89b7b80780cbb7c1e2678ec7736db): npm-install-checks@2.0.1
- [f3fd722](https://github.com/npm/npm/commit/f3fd722d9fcafe4c58964a7301f02763491ed8e4): test: Cleanup bundled dependencies test
- [4d6018a](https://github.com/npm/npm/commit/4d6018a712e1e8c3780cd3d02e5dda7d2da85fb9): pack: Don't bother reading the tree if nothing is bundled
- [330b496](https://github.com/npm/npm/commit/330b49699acecc53ea36c46e05c92dfc092c2c9d): pack: Pass in our tree object via closures instead of properties
- [829921f](https://github.com/npm/npm/commit/829921fac2790f103035a34042b85181d9db1307): validate-tree: When normalize-package-data throws, capture that as a warning


There are 19 commits in total. See the [full diff](https://github.com/npm/npm/compare/d901d1343cef3f0ae1e4422b615f847997c0c04a...5653606a12616dbe39d456be7238f00fe51f8816).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>